### PR TITLE
Add Deploy to Heroku button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,10 @@ gem 'puma'
 # Environment
 gem 'dotenv-rails'
 
+gem 'sqlite3', group: "sqlite3"
+
 group :production do
   gem 'pg'
-  gem 'sqlite3'
   # gem 'rails_12factor'
 end
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Heaven is higher than a cloud.
 [![Code Climate](https://codeclimate.com/github/alfa-jpn/BotHeaven/badges/gpa.svg)](https://codeclimate.com/github/alfa-jpn/BotHeaven)
 [![Build Status](https://travis-ci.org/alfa-jpn/BotHeaven.svg?branch=master)](https://travis-ci.org/alfa-jpn/BotHeaven)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 ## Install
 This is rails application.
 - System Required

--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
   "env": {
     "BUNDLE_WITHOUT": {
       "description": "bundle install --without <these>",
-      "value": "test:development"
+      "value": "test:development:sqlite3"
     },
     "SLACK_TEAM_ID": {
       "description": "check at https://api.slack.com/methods/auth.test/test",

--- a/app.json
+++ b/app.json
@@ -1,0 +1,42 @@
+{
+  "name": "Bot Heaven",
+  "description": "Bot farm of SLACK.",
+  "keywords": ["Slack"],
+  "scripts": {
+    "postdeploy": "bundle exec rake db:create db:migrate"
+  },
+  "env": {
+    "BUNDLE_WITHOUT": {
+      "description": "bundle install --without <these>",
+      "value": "test:development"
+    },
+    "SLACK_TEAM_ID": {
+      "description": "check at https://api.slack.com/methods/auth.test/test",
+      "value": ""
+    },
+    "SLACK_APP_ID": {
+      "description": "visit https://api.slack.com/applications and input here",
+      "value": ""
+    },
+    "SLACK_APP_SECRET": {
+      "description": "visit https://api.slack.com/applications and input here",
+      "value": ""
+    },
+    "SLACK_BOT_NAME": {
+      "description": "visit https://slack.com/services/new/bot and input here",
+      "value": ""
+    },
+    "SLACK_BOT_TOKEN": {
+      "description": "visit https://slack.com/services/new/bot and input here",
+      "value": ""
+    },
+    "SECRET_KEY_BASE": {
+      "description": "Any encryption key",
+      "generator": "secret"
+    },
+    "RAILS_SERVE_STATIC_FILES": "1"
+  },
+  "addons": [
+    "papertrail"
+  ]
+}


### PR DESCRIPTION
便利そうだったのでDeploy to Herokuボタンに対応してワンクリックでデプロイできるようにしました。

![2015-05-26 12 38 44](https://cloud.githubusercontent.com/assets/608755/7804866/2da4d9a2-03a4-11e5-80ab-58486f491f88.png)

自分のHerokuアカウントでデプロイできるところまで確認しています

app.jsonの説明文は適当なのでよしなに編集お願いします

## 公式資料
* https://devcenter.heroku.com/articles/heroku-button
* https://devcenter.heroku.com/articles/app-json-schema